### PR TITLE
Slimming down has to be done on the same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN mkdir -p /root/work/
 WORKDIR /root/work/
 
-# install git
-RUN apt-get -y update && apt-get -y install git
-
-# slim down image
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man/?? /usr/share/man/??_*
+# install git and slim down image
+RUN apt-get -y update && apt-get -y install git && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man/?? /usr/share/man/??_*
 
 # run a CMD to show git is installed
 CMD git help


### PR DESCRIPTION
In the install-layer you created temporary files that you wanted to remove in the next layer.
But images can only grow larger (or stay the same size) when adding layers.
So what actually happened in the slim-down-layer is that the files are being "ignored" but still take up space.
On my system my commit shrunk the space from 162MB to 145MB